### PR TITLE
Add getting started, SSH guide, and PLR Z-offset fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This is a summary collection of various config tweaks, print profiles, and links
 
 ### [Fixing lead screw rotation resistance](./content/lead-screw-resistance-fix/README.md)
 
+### [PLR Z-Offset Bug Fix](./content/plr-z-offset/README.md)
+
 ---
 
 ## Software Installation

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ This is a summary collection of various config tweaks, print profiles, and links
 
 ---
 
+## Getting Started
+
+### [Connecting to Your Printer via SSH](./content/ssh-guide/README.md)
+
+### [Getting Started with the Qidi Q2 / Q2C](./content/getting-started/README.md)
+
+---
+
 ## Issues and Possible Fixes
 
 ### [Bed Collision Fix](./content/bed-collision-fix/README.md)

--- a/content/getting-started/README.md
+++ b/content/getting-started/README.md
@@ -1,0 +1,81 @@
+# Getting Started with the Qidi Q2 / Q2C
+
+> This guide picks up after first boot — printer is online, connected to your network, and accessible via Fluidd.
+
+> **New to SSH?** Most steps in this guide require terminal access to your printer. If you haven't set that up yet, start here: [Connecting to Your Printer via SSH](../ssh-guide/README.md)
+
+> **Q2C Note:** The Q2 and Q2C are nearly identical in hardware and software. Differences are noted inline where they exist. The only hardware difference is the Q2C does not include a chamber heater.
+
+---
+
+## 1. Add `screws_tilt_adjust` to printer.cfg
+
+The stock printer.cfg defines screw positions early in the file but is **missing the `[screws_tilt_adjust]` section entirely**. Without it, Klipper's assisted bed leveling won't work.
+
+Add the following block to the **end of printer.cfg**, just before the `#*# <---------------------- SAVE_CONFIG ---------------------->` section:
+
+```ini
+[screws_tilt_adjust]
+horizontal_move_z: 10
+screw_thread: CW-M4
+speed: 50
+
+screw1: 30,30
+screw1_name: front left
+screw2: 240,30
+screw2_name: front right
+screw3: 240,240
+screw3_name: rear right
+screw4: 30,240
+screw4_name: rear left
+```
+
+After saving, do a firmware restart. You can now run `SCREWS_TILT_CALCULATE` from the Fluidd console to get turn-by-turn adjustment instructions for each bed screw.
+
+---
+
+## 2. Bed Leveling Sequence
+
+Getting a flat, properly trammed bed takes a few steps done in the right order. Skipping steps or doing them out of order wastes time.
+
+**Recommended order:**
+
+1. **Z Tilt Adjust** — Run `Z_TILT_ADJUST` from the Fluidd console. This corrects any tilt between the two Z lead screws using the load cell probe.
+
+2. **Platform Calibration** — Run this from the Qidi menu on the touchscreen. This is Qidi's built-in bed calibration routine.
+
+3. **Manual bed screw adjustment if needed** — If the bed is significantly crooked, loosen the bed screws and physically reposition the bed so it doesn't contact the frame during travel, then repeat from step 1. See: [Bed Tramming with Nylok Nuts](../bed-tramming/README.md)
+
+> **Tip:** `SCREWS_TILT_CALCULATE` (added in step 1 above) gives you clockwise/counterclockwise turn amounts per screw corner. Use it before and after manual adjustments to verify.
+
+---
+
+## 3. Disable Unused System Processes
+
+The Q2 runs several background services that have no function during normal printing. Disabling them frees memory and can make the Fluidd interface feel more responsive.
+
+See [Bluedrool's process cleanup guide](https://github.com/bluedrool/Qidi-Q2-tuning-tweaks-and-mods/blob/main/docs/processes.md) for the full list and commands.
+
+> **⚠️ Qidi Link App Users:** If you use the Qidi Link mobile app, **do not disable** `algo_app`, `QIDILink-client`, `xl2tpd`, `strongswan`, or `openvpn`. These services are likely required for app connectivity. Disable only what you're confident you don't need.
+
+> **Q2C Note:** Most services on that list are already absent on the Q2C due to its newer firmware image (board revision dated May 2025). Only `pulseaudio` and `bluetoothd` have been confirmed still running — address those with:
+>
+> ```bash
+> sudo systemctl disable --now bluetooth
+> systemctl --user mask pulseaudio.service
+> systemctl --user mask pulseaudio.socket
+> ```
+>
+> That said, **it's still worth going through the full list yourself** using `htop` or `ps aux`. Firmware varies and something may have slipped through. If you find anything still running that isn't on the confirmed list, please share your findings in the Discord — this data helps keep this guide accurate for everyone.
+>
+> After a reboot, a clean Q2C idles at approximately **132MB used (~29% of 512MB RAM)** — significantly lower than a Q2 at the same point (~50%+). This headroom matters if you plan to run Spoolman, KlipperScreen, or other addons.
+
+---
+
+## Next Steps
+
+Once your bed is trammed and your config is clean, good next steps are:
+
+- [Randomizing Z Homing Probe Location](../randomize-probing/README.md) — reduces wear on one spot of the bed surface
+- [Displaying Toolhead and Host CPU Temperatures](../temperature-monitoring/README.md) — useful for monitoring
+- [Installing Spoolman](../spoolman-installation/README.md) — filament tracking

--- a/content/plr-z-offset/README.md
+++ b/content/plr-z-offset/README.md
@@ -73,3 +73,9 @@ Run this in the Fluidd/Mainsail console, substituting your actual tuned offset. 
 
 - Qidi Q2 / Q2C with a custom `z_offset` in `saved_variables.cfg`
 - Most noticeable with thicker build plates that require a larger offset correction
+
+## Verified On
+
+- Firmware 1.1.0 and 1.1.1
+
+Behavior on newer firmware versions is unknown — if you've tested this on a later version, feel free to update this page.

--- a/content/plr-z-offset/README.md
+++ b/content/plr-z-offset/README.md
@@ -1,0 +1,75 @@
+# PLR Z-Offset Bug
+
+When a print is interrupted by a power loss, Qidi's Power Loss Recovery (PLR) system resumes the print using a shell script (`plr.sh`). Due to the order of operations in the resume sequence, any custom Z offset stored in `saved_variables.cfg` is silently ignored — the printer resumes at the wrong Z height.
+
+---
+
+## Symptoms
+
+- After a power loss, the print resumes printing too high or too low relative to where it left off
+- The `z_offset` value in `saved_variables.cfg` appears correct but has no effect on resume
+- The issue is more noticeable with non-standard build plates that require a z offset correction (e.g. thicker plates like the Tyson build plate)
+
+---
+
+## Root Cause
+
+The PLR resume sequence in `RESUME_INTERRUPTED` calls `set_zoffset` first, then runs the shell script via `RUN_SHELL_COMMAND CMD=POWER_LOSS_RESUME`. Inside `plr.sh`, the following lines execute:
+
+```bash
+echo "SET_KINEMATIC_POSITION Z=$z_position"
+...
+echo "G1 Z$z_position"
+```
+
+`SET_KINEMATIC_POSITION` resets the coordinate system and the subsequent `G1 Z` move positions the head without any gcode offset applied. Whatever `set_zoffset` did earlier in the macro is effectively overwritten.
+
+---
+
+## Fix
+
+Edit `plr.sh` on the printer:
+
+```bash
+nano ~/scripts/plr/plr.sh
+```
+
+Find this block:
+
+```bash
+echo "G90"
+echo "G1 Z$z_position"
+grep -E "M83|M82" "$TEMP_FILE.header" | tail -n 1
+```
+
+Change it to:
+
+```bash
+echo "G90"
+echo "G1 Z$z_position"
+echo "set_zoffset"
+grep -E "M83|M82" "$TEMP_FILE.header" | tail -n 1
+```
+
+No Klipper restart is required — shell script changes take effect immediately on the next PLR resume.
+
+---
+
+## Bonus: z_offset Corruption After PLR
+
+If you manually adjusted your Z offset mid-print during a PLR resume (e.g. via `SET_GCODE_OFFSET Z=0.05`), the `save_zoffset` macro at print end will save that adjusted value to `saved_variables.cfg`, overwriting your tuned offset.
+
+To restore the correct value without rebooting:
+
+```
+SAVE_VARIABLE VARIABLE=z_offset VALUE=0.012
+```
+
+Run this in the Fluidd/Mainsail console, substituting your actual tuned offset. Unlike editing `saved_variables.cfg` directly in the config editor, `SAVE_VARIABLE` updates both the file and the in-memory value simultaneously — no restart needed.
+
+---
+
+## Affected Hardware
+
+- Qidi Q2 / Q2C with a custom `z_offset` in `saved_variables.cfg`
+- Most noticeable with thicker build plates that require a larger offset correction

--- a/content/ssh-guide/README.md
+++ b/content/ssh-guide/README.md
@@ -1,0 +1,99 @@
+# Connecting to Your Printer via SSH
+
+SSH lets you access your printer's terminal directly from your computer. This is needed for many configuration tasks, installing software, and troubleshooting.
+
+---
+
+## Default Credentials
+
+| Field    | Value       |
+|----------|-------------|
+| Username | `makerbase` |
+| Password | `mks`       |
+| Port     | `22`        |
+
+---
+
+## Finding Your Printer's IP Address
+
+On the printer touchscreen, go to **Settings → Network**. Your IP address is displayed at the top of the screen for both WiFi and wired connections.
+
+
+
+![Network settings screen showing IP address](images/network-screen.png)
+
+
+
+> **Tip:** Assign your printer a static IP in your router's DHCP settings so the address never changes between reboots.
+
+---
+
+## Windows
+
+### Option 1: Windows Terminal / Command Prompt (built-in)
+
+Windows 10 and 11 include SSH natively. Open **Command Prompt** or **Windows Terminal** and run:
+ssh makerbase@YOUR_PRINTER_IP
+Enter `mks` when prompted for the password. That's it.
+
+### Option 2: Bitvise SSH Client (recommended for heavy use)
+
+[Bitvise](https://www.bitvise.com/ssh-client) is free and adds several useful features over a basic terminal:
+
+- **Built-in graphical file browser** — drag and drop files to/from the printer without separate tools
+- **Multiple terminal tabs** — useful when you want to run a command and monitor logs simultaneously
+- **Saved profiles** — if you have multiple printers, save a profile for each and switch between them instantly
+
+**Setup:**
+1. Download and install Bitvise from [bitvise.com/ssh-client](https://www.bitvise.com/ssh-client)
+2. In the **Host** field enter your printer's IP
+3. Port: `22`
+4. Username: `makerbase`
+5. Password: `mks`
+6. Click **Save profile** to save it for next time
+7. Click **Log in**
+
+The terminal window and file browser open automatically after login.
+
+---
+
+## macOS
+
+macOS has SSH built in. Open **Terminal** (Applications → Utilities → Terminal) and run:
+ssh makerbase@YOUR_PRINTER_IP
+Enter `mks` when prompted.
+
+> If you want a graphical file browser similar to Bitvise, [Cyberduck](https://cyberduck.io/) is a free option — connect using SFTP with the same credentials.
+
+---
+
+## Linux
+
+You already know what you're doing. Just in case:
+
+```bash
+ssh makerbase@YOUR_PRINTER_IP
+For file transfer, scp or sftp work fine, or mount via SSHFS if you prefer.
+After Connecting
+You should see a prompt like:
+makerbase@mkspi:~$
+You're in. Some useful first commands:
+# Check memory usage
+free -h
+
+# View running processes
+htop
+
+# Check Klipper/Moonraker service status
+sudo systemctl status klipper
+sudo systemctl status moonraker
+Troubleshooting
+Connection refused / timeout:
+Double check the IP on the touchscreen — it may have changed if you don't have a static IP set
+Make sure the printer is fully booted (give it 60 seconds after powering on)
+Confirm you're on the same network as the printer
+Permission denied:
+Username is makerbase, password is mks — both lowercase, no spaces
+---
+
+Watch out for the code blocks — the triple backticks are the most likely thing to get mangled by autocorrect.

--- a/content/ssh-guide/README.md
+++ b/content/ssh-guide/README.md
@@ -36,24 +36,15 @@ Windows 10 and 11 include SSH natively. Open **Command Prompt** or **Windows Ter
 ssh makerbase@YOUR_PRINTER_IP
 Enter `mks` when prompted for the password. That's it.
 
-### Option 2: Bitvise SSH Client (recommended for heavy use)
+### Option 2: GUI SSH Clients
 
-[Bitvise](https://www.bitvise.com/ssh-client) is free and adds several useful features over a basic terminal:
+If you want more than a basic terminal, several free GUI clients are popular in the community. All use the same credentials (host = printer IP, port `22`, username `makerbase`, password `mks`).
 
-- **Built-in graphical file browser** — drag and drop files to/from the printer without separate tools
-- **Multiple terminal tabs** — useful when you want to run a command and monitor logs simultaneously
-- **Saved profiles** — if you have multiple printers, save a profile for each and switch between them instantly
+**[Bitvise](https://www.bitvise.com/ssh-client)** — Good starting point if you're new to SSH. Opens a graphical file browser alongside the terminal automatically, so you can drag and drop files to/from the printer without any extra tools. Also supports saved profiles if you have multiple printers.
 
-**Setup:**
-1. Download and install Bitvise from [bitvise.com/ssh-client](https://www.bitvise.com/ssh-client)
-2. In the **Host** field enter your printer's IP
-3. Port: `22`
-4. Username: `makerbase`
-5. Password: `mks`
-6. Click **Save profile** to save it for next time
-7. Click **Log in**
+**[PuTTY](https://www.putty.org/)** — The classic. Lightweight, no install required, and has been around forever so there's no shortage of tutorials. Terminal only — no built-in file browser.
 
-The terminal window and file browser open automatically after login.
+**[MobaXterm](https://mobaxterm.mobatek.net/)** — Feature-rich option that includes a built-in file browser (like Bitvise), multiple tabs, and a bunch of other network tools bundled in. The free Home edition is plenty for printer use.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `content/getting-started/README.md` — basic intro page for new Q2/Q2C owners
- Adds `content/ssh-guide/README.md` — how to connect via SSH on Windows/macOS/Linux, covering built-in terminal plus Bitvise, PuTTY, and MobaXterm
- Adds `content/plr-z-offset/README.md` — documents the PLR resume bug where `plr.sh` overwrites the Z offset set by `set_zoffset`, with root cause explanation and a one-line fix

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm file paths follow `content/<topic>/README.md` convention
- [ ] PLR fix tested on Q2 with custom z_offset in saved_variables.cfg

🤖 Generated with [Claude Code](https://claude.com/claude-code)